### PR TITLE
fix: curve finance link

### DIFF
--- a/src/blocks/ReviewsSlider.vue
+++ b/src/blocks/ReviewsSlider.vue
@@ -58,7 +58,7 @@ export default Vue.extend({
       default: (): Review[] => {
         return [
           {
-            link: "https://resources.curve.fi/guides/more.../layer-2-meets-curve-with-zksync",
+            link: "https://blog.matter-labs.io/curve-zksync-l2-ethereums-first-user-defined-zk-rollup-smart-contract-5a72c496b350",
             thumbnail: "curve.svg",
             thumbnailAlt: "Curve Finance - automatic market-making for stablecoins and not only",
             thumbnailTitle: "Curve + zkSync L2: Ethereum’s first user-defined ZK rollup smart contract!",


### PR DESCRIPTION
The current link to Curve Finance leads to a 404. 

Added a pull request since I can't open an issue on the repo 😊 . I changed the link to an old blog post, but maybe it's better to update it to a more up to date one.